### PR TITLE
Add standalone kmeans module and tests

### DIFF
--- a/kmeans.py
+++ b/kmeans.py
@@ -1,0 +1,45 @@
+import random
+from typing import List, Sequence, Tuple
+
+
+def _euclidean(p: Sequence[float], q: Sequence[float]) -> float:
+    return sum((a - b) ** 2 for a, b in zip(p, q)) ** 0.5
+
+
+def _mean_point(points: List[Sequence[float]]) -> List[float]:
+    n = len(points[0])
+    return [sum(p[i] for p in points) / len(points) for i in range(n)]
+
+
+def kmeans(X: List[Sequence[float]], k: int, max_iters: int = 300) -> Tuple[List[int], List[List[float]]]:
+    """Simple k-means clustering implementation without external dependencies."""
+    if k <= 0:
+        raise ValueError("k must be positive")
+    if k > len(X):
+        raise ValueError("k cannot exceed number of data points")
+
+    centroids = [X[i] for i in random.sample(range(len(X)), k)]
+
+    for _ in range(max_iters):
+        labels = []
+        for x in X:
+            distances = [_euclidean(x, c) for c in centroids]
+            labels.append(distances.index(min(distances)))
+
+        new_centroids = []
+        changed = False
+        for i in range(k):
+            cluster_points = [x for x, label in zip(X, labels) if label == i]
+            if cluster_points:
+                new_c = _mean_point(cluster_points)
+            else:
+                new_c = centroids[i]
+            if new_c != centroids[i]:
+                changed = True
+            new_centroids.append(new_c)
+
+        centroids = new_centroids
+        if not changed:
+            break
+
+    return labels, centroids

--- a/tests/test_kmeans.py
+++ b/tests/test_kmeans.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import random
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from kmeans import kmeans
+
+
+def test_kmeans_basic():
+    random.seed(0)
+    k = 3
+    centers = [(0, 0), (5, 5), (-5, -5)]
+    data = []
+    for cx, cy in centers:
+        for _ in range(30):
+            data.append([random.gauss(cx, 0.1), random.gauss(cy, 0.1)])
+
+    labels, centroids = kmeans(data, k)
+
+    assert len(centroids) == k
+    assert all(len(c) == 2 for c in centroids)
+    assert len(labels) == len(data)
+    assert min(labels) >= 0
+    assert max(labels) < k
+


### PR DESCRIPTION
## Summary
- extract `kmeans` implementation into a new pure‑Python module
- add `tests/test_kmeans.py` with a basic clustering test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bea62c1e083219b3d293fbddcebc8